### PR TITLE
fix: the default clickhouse installation is distributed, only turn on…

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 14.1.0
+version: 14.1.1
 appVersion: 22.5.0
 dependencies:
   - name: redis

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -44,7 +44,11 @@ data:
             "errors_v2_ro",
             "profiles",
         },
-        {{- if .Values.externalClickhouse.singleNode }}
+        {{- /*
+          The default clickhouse installation runs in distributed mode, while the external
+          clickhouse configured can be configured any way you choose
+        */}}
+        {{- if and .Values.externalClickhouse.singleNode (not .Values.clickhouse.enabled) }}
         "single_node": True,
         {{- else }}
         "single_node": False,


### PR DESCRIPTION
… single node when clickhouse is disabled (#624)

* The default clickhouse installation is distributed, only turn on single node when clickhouse is disabled

* Bump the chart version to satisfy the linter